### PR TITLE
Fix the short title ID handling

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -115,7 +115,7 @@ $(document).ready(function() {
         titleID = titleID + titleIDPost;
       }
 
-      titleID = titleIDPre + pad(titleID, 8);
+      titleID = titleIDPre.substr(0,8) + pad(titleID, 8);
     }
 
     titleID = pad(titleID, 16);


### PR DESCRIPTION
When titleIDPre was modified to include an extra zero it broke the function that converts the short ID format to the full ID for validation.

This fixes that bug.